### PR TITLE
CONTRIB-9440: fix for fixed number of parameters

### DIFF
--- a/classes/bigbluebuttonbn/mod_form_addons.php
+++ b/classes/bigbluebuttonbn/mod_form_addons.php
@@ -41,7 +41,7 @@ class mod_form_addons extends \mod_bigbluebuttonbn\local\extension\mod_form_addo
         if (!empty($bigbluebuttonbndata->id)) {
             $data = $this->retrieve_additional_data($bigbluebuttonbndata->id);
             $this->bigbluebuttonbndata = (object) array_merge((array) $this->bigbluebuttonbndata, $data);
-            $this->bigbluebuttonbndata->flexurl_paramcount = count($data);
+            $this->bigbluebuttonbndata->flexurl_paramcount = count($data["flexurl_".array_key_first(utils::PARAM_TYPES)]);
         }
     }
 

--- a/version.php
+++ b/version.php
@@ -25,5 +25,5 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version   = 2023020800;
-$plugin->requires  = 2023020300;
+$plugin->requires  = 2022112800;
 $plugin->component = 'bbbext_flexurl';


### PR DESCRIPTION
This solves the bug for the fixed number of parameters, but we may want to refactor the way the data is handled so instead of 3 disconnected arrays like this

{
"flexurl_eventtype":["2","1","2","2"],
"flexurl_paramname":["custom_name","another","global_param_new","new_more"],
"flexurl_paramvalue":["user.alternatename","activityinfo.name","courseinfo.idnumber","activityinfo.id"]
}

we have a distinct objcet per row like this

[
[{"flexurl_eventtype":2},{"flexurl_paramname":"custom_name"},{"flexurl_paramvalue":"user.alternatename"}],
[{"flexurl_eventtype":1},{"flexurl_paramname":"another"},{"flexurl_paramvalue":"activityinfo.name"}],
[{"flexurl_eventtype":2},{"flexurl_paramname":"global_param_new"},{"flexurl_paramvalue":"courseinfo.idnumber"}],
[{"flexurl_eventtype":2},{"flexurl_paramname":"new_more"},{"flexurl_paramvalue":"activityinfo.id"}],
]

of course this would lead to a bigger change as the logic for rendering the data would need to change