### PR TITLE
CONTRIB-9438: use autocomplete to enter new values 

### DIFF
--- a/classes/bigbluebuttonbn/action_url_addons.php
+++ b/classes/bigbluebuttonbn/action_url_addons.php
@@ -52,8 +52,7 @@ class action_url_addons extends \mod_bigbluebuttonbn\local\extension\action_url_
                     $eventtypes[$flexurlrecord->eventtype] != $action) {
                     continue;
                 }
-
-                $metadata[$flexurlrecord->paramname] = utils::get_value_for_field($flexurlrecord->paramvalue, $instance);
+                $metadata[$flexurlrecord->paramname] = utils::get_real_value($flexurlrecord->paramvalue, $instance);
 
             }
         }

--- a/classes/bigbluebuttonbn/mod_form_addons.php
+++ b/classes/bigbluebuttonbn/mod_form_addons.php
@@ -16,6 +16,7 @@
 namespace bbbext_flexurl\bigbluebuttonbn;
 
 use bbbext_flexurl\utils;
+use MoodleQuickForm;
 use stdClass;
 
 /**
@@ -41,7 +42,7 @@ class mod_form_addons extends \mod_bigbluebuttonbn\local\extension\mod_form_addo
         if (!empty($bigbluebuttonbndata->id)) {
             $data = $this->retrieve_additional_data($bigbluebuttonbndata->id);
             $this->bigbluebuttonbndata = (object) array_merge((array) $this->bigbluebuttonbndata, $data);
-            $this->bigbluebuttonbndata->flexurl_paramcount = count($data["flexurl_".array_key_first(utils::PARAM_TYPES)]);
+            $this->bigbluebuttonbndata->flexurl_paramcount = count($data["flexurl_".array_key_first(utils::PARAM_TYPES)] ?? []);
         }
     }
 
@@ -162,6 +163,7 @@ class mod_form_addons extends \mod_bigbluebuttonbn\local\extension\mod_form_addo
      * Add new form field definition
      */
     public function add_fields(): void {
+        global $CFG;
         $this->mform->addElement('header', 'flexurl', get_string('pluginname', 'bbbext_flexurl'));
 
         $paramcount = optional_param('flexurl_paramcount', $this->bigbluebuttonbndata->flexurl_paramcount ?? 0, PARAM_RAW);
@@ -179,10 +181,13 @@ class mod_form_addons extends \mod_bigbluebuttonbn\local\extension\mod_form_addo
                 ['size' => '6']
             );
             $paramvalue = $this->mform->createElement(
-                'selectgroups',
+                'autocomplete',
                 "flexurl_paramvalue[$index]",
                 get_string('param_value', 'bbbext_flexurl'),
                 utils::get_options_for_parameters(),
+                [
+                    'tags' => true,
+                ]
             );
             $paramtype = $this->mform->createElement(
                 'select',

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -117,7 +117,7 @@ class utils {
     /**
      * Get value for this parameter
      *
-     * @param string $field
+     * @param string $rawvalue
      * @param instance $instance
      * @return string
      */

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -57,10 +57,14 @@ class utils {
         $selectedptypes = array_map('trim', $selectedptypes);
         foreach ($parametertypes as $key => $value) {
             if (in_array($key, $selectedptypes)) {
-                $options[$value] = self::get_fields_for_parameter($key);
+                $options = array_merge($options, self::get_fields_for_parameter($key));
             }
         }
         ksort($options);
+        // Now add a marker so we know they are placeholder for values.
+        $options = array_combine(array_map(function($key) {
+            return '%' . $key . '%';
+        }, array_keys($options)), $options);
         return $options;
     }
 
@@ -110,7 +114,22 @@ class utils {
             return '';
         }
     }
-
+    /**
+     * Get value for this parameter
+     *
+     * @param string $field
+     * @param instance $instance
+     * @return string
+     */
+    public static function get_real_value(string $rawvalue, instance $instance): string {
+        // First check if there is a marker for a placeholder.
+        if (strpos($rawvalue, '%') === 0) {
+            $field = substr($rawvalue, 1, -1);
+            return self::get_value_for_field($field, $instance);
+        } else {
+            return $rawvalue;
+        }
+    }
     /**
      * Get user fields prefixed by user.
      *

--- a/tests/utils_test.php
+++ b/tests/utils_test.php
@@ -115,45 +115,39 @@ class utils_test extends \advanced_testcase {
         $this->assertNotEmpty($options);
         $this->assertEquals(
             json_decode('{
-"Activity information (ACTIVITY)": {
-        "activityinfo.id": "activityinfo.id",
-    "activityinfo.name": "activityinfo.name",
-    "activityinfo.url": "activityinfo.url",
-    "activityinfo.iconurl": "activityinfo.iconurl"
-},
-"Course info (COURSE)": {
-    "courseinfo.id": "courseinfo.id",
-    "courseinfo.fullname": "courseinfo.fullname",
-    "courseinfo.shortname": "courseinfo.shortname",
-    "courseinfo.idnumber": "courseinfo.idnumber",
-    "courseinfo.summary": "courseinfo.summary",
-    "courseinfo.summaryformat": "courseinfo.summaryformat",
-    "courseinfo.startdate": "courseinfo.startdate",
-    "courseinfo.enddate": "courseinfo.enddate",
-    "courseinfo.visible": "courseinfo.visible",
-    "courseinfo.showactivitydates": "courseinfo.showactivitydates",
-    "courseinfo.showcompletionconditions": "courseinfo.showcompletionconditions",
-    "courseinfo.pdfexportfont": "courseinfo.pdfexportfont",
-    "courseinfo.fullnamedisplay": "courseinfo.fullnamedisplay",
-    "courseinfo.viewurl": "courseinfo.viewurl",
-    "courseinfo.courseimage": "courseinfo.courseimage",
-    "courseinfo.progress": "courseinfo.progress",
-    "courseinfo.hasprogress": "courseinfo.hasprogress",
-    "courseinfo.isfavourite": "courseinfo.isfavourite",
-    "courseinfo.hidden": "courseinfo.hidden",
-    "courseinfo.timeaccess": "courseinfo.timeaccess",
-    "courseinfo.showshortname": "courseinfo.showshortname",
-    "courseinfo.coursecategory": "courseinfo.coursecategory"
-},
-"Basic user info (USER)": {
-    "user.alternatename": "user.alternatename",
-    "user.email": "user.email",
-    "user.firstname": "user.firstname",
-    "user.firstnamephonetic": "user.firstnamephonetic",
-    "user.lastname": "user.lastname",
-    "user.lastnamephonetic": "user.lastnamephonetic",
-    "user.middlename": "user.middlename"
-}
+    "%activityinfo.id%": "activityinfo.id",
+    "%activityinfo.name%": "activityinfo.name",
+    "%activityinfo.url%": "activityinfo.url",
+    "%activityinfo.iconurl%": "activityinfo.iconurl",
+    "%courseinfo.id%": "courseinfo.id",
+    "%courseinfo.fullname%": "courseinfo.fullname",
+    "%courseinfo.shortname%": "courseinfo.shortname",
+    "%courseinfo.idnumber%": "courseinfo.idnumber",
+    "%courseinfo.summary%": "courseinfo.summary",
+    "%courseinfo.summaryformat%": "courseinfo.summaryformat",
+    "%courseinfo.startdate%": "courseinfo.startdate",
+    "%courseinfo.enddate%": "courseinfo.enddate",
+    "%courseinfo.visible%": "courseinfo.visible",
+    "%courseinfo.showactivitydates%": "courseinfo.showactivitydates",
+    "%courseinfo.showcompletionconditions%": "courseinfo.showcompletionconditions",
+    "%courseinfo.pdfexportfont%": "courseinfo.pdfexportfont",
+    "%courseinfo.fullnamedisplay%": "courseinfo.fullnamedisplay",
+    "%courseinfo.viewurl%": "courseinfo.viewurl",
+    "%courseinfo.courseimage%": "courseinfo.courseimage",
+    "%courseinfo.progress%": "courseinfo.progress",
+    "%courseinfo.hasprogress%": "courseinfo.hasprogress",
+    "%courseinfo.isfavourite%": "courseinfo.isfavourite",
+    "%courseinfo.hidden%": "courseinfo.hidden",
+    "%courseinfo.timeaccess%": "courseinfo.timeaccess",
+    "%courseinfo.showshortname%": "courseinfo.showshortname",
+    "%courseinfo.coursecategory%": "courseinfo.coursecategory",
+    "%user.alternatename%": "user.alternatename",
+    "%user.email%": "user.email",
+    "%user.firstname%": "user.firstname",
+    "%user.firstnamephonetic%": "user.firstnamephonetic",
+    "%user.lastname%": "user.lastname",
+    "%user.lastnamephonetic%": "user.lastnamephonetic",
+    "%user.middlename%": "user.middlename"
 }', true)
             , $options);
     }


### PR DESCRIPTION
From the original PR.

- Use %xxx% as a marker for values that will need to replaced
- You can now enter literal values that will be passed along with the join/create query.