### PR TITLE
CONTRIB-9449: Fix parameter options

### DIFF
--- a/classes/bigbluebuttonbn/mod_form_addons.php
+++ b/classes/bigbluebuttonbn/mod_form_addons.php
@@ -188,6 +188,7 @@ class mod_form_addons extends \mod_bigbluebuttonbn\local\extension\mod_form_addo
                     'tags' => true,
                 ]
             );
+            $paramvalue->setValue('');
             $paramtype = $this->mform->createElement(
                 'select',
                 "flexurl_eventtype[$index]",

--- a/classes/bigbluebuttonbn/mod_instance_helper.php
+++ b/classes/bigbluebuttonbn/mod_instance_helper.php
@@ -50,10 +50,16 @@ class mod_instance_helper extends \mod_bigbluebuttonbn\local\extension\mod_insta
      */
     private function sync_additional_params(stdClass $bigbluebuttonbn): void {
         global $DB;
+        // Retrieve existing parameters from the database.
+        $existingparams = $DB->get_records(self::SUBPLUGIN_TABLE, ['bigbluebuttonbnid' => $bigbluebuttonbn->id]);
         // Checks first.
         $count = $bigbluebuttonbn->flexurl_paramcount ?? 0;
         foreach (utils::PARAM_TYPES as $type => $paramtype) {
             if (!isset($bigbluebuttonbn->{'flexurl_' . $type})) {
+                // If the parameters were deleted, the deletion must be synced in the DB.
+                if (!empty($existingparams)) {
+                    continue;
+                }
                 return;
             }
             if ($count != count($bigbluebuttonbn->{'flexurl_' . $type})) {


### PR DESCRIPTION
* Add placeholder value for dropdown list instead of predefined value e.g. activity.info.iconurl
* After form submission parameter deleted in form is deleted in DB